### PR TITLE
Feature/retry strategies

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@seriouslag/httpclient",
-  "version": "0.0.11",
+  "version": "0.0.12",
   "description": "Typed wrapper HttpClient for axios",
   "main": "dist/index.umd.js",
   "browser": "dist/index.umd.min.js",

--- a/src/HttpClient.test.ts
+++ b/src/HttpClient.test.ts
@@ -300,7 +300,7 @@ describe('HttpClient', () => {
     cancelToken.abort();
 
     expect.assertions(2);
-    expect(cancel).toBeCalledTimes(1);
+    expect(cancel).toBeCalledTimes(0);
     const result = await promise;
     expect(result).toEqual({
       data:       responseData.data,

--- a/src/HttpClient.test.ts
+++ b/src/HttpClient.test.ts
@@ -473,13 +473,14 @@ describe('HttpClient', () => {
     } catch (e) {
       expect(request).toBeCalledTimes(1);
       expect(request).toBeCalledWith({
-        url:          'www.google.com',
-        method:       'GET',
-        data:         undefined,
-        headers:      undefined,
-        params:       undefined,
-        cancelToken:  undefined,
-        responseType: undefined,
+        url:            'www.google.com',
+        method:         'GET',
+        data:           undefined,
+        headers:        undefined,
+        params:         undefined,
+        cancelToken:    undefined,
+        responseType:   undefined,
+        validateStatus: expect.any(Function),
       });
     }
   });

--- a/src/HttpClient.ts
+++ b/src/HttpClient.ts
@@ -12,8 +12,7 @@ export interface ApiConfig {
   /** If specified, a new axios instance is used instead of the one instantiated in the HttpClient's constructor */
   noGlobal?: boolean;
   /** The headers that will be used in the HTTP call. Global headers will be added to these.
-   *
-   *  TODO - Test when noGlobal is true if global headers are added to the request
+   *  // TODO: Test when noGlobal is true if global headers are added to the request
   */
   headers?: Record<string, string>;
   /** The body of the request that will be sent */
@@ -24,7 +23,6 @@ export interface ApiConfig {
   params?: any;
   /** The encoding of the response */
   responseEncoding?: string;
-  /** The strategy used to handle requests */
 }
 
 /** Response data from using the fetch request */

--- a/src/HttpClient.ts
+++ b/src/HttpClient.ts
@@ -13,7 +13,7 @@ export interface ApiConfig {
   noGlobal?: boolean;
   /** The headers that will be used in the HTTP call. Global headers will be added to these.
    *
-   * TODO - Test when noGlobal is true if global headers are added to the request
+   *  TODO - Test when noGlobal is true if global headers are added to the request
   */
   headers?: Record<string, string>;
   /** The body of the request that will be sent */

--- a/src/HttpClient.ts
+++ b/src/HttpClient.ts
@@ -223,6 +223,9 @@ export class HttpClient {
         // do not cancel if already canceled
         if (hasCanceled)
           return;
+        // do not cancel if request is already resolved
+        if (hasResolvedRequest)
+          return;
         // if signal is aborted then cancel the axios source
         source.cancel(ABORT_MESSAGE);
         hasCanceled = true;

--- a/src/HttpClient.ts
+++ b/src/HttpClient.ts
@@ -4,13 +4,16 @@ import { Logger } from './Logger';
 import { ABORT_MESSAGE, ERROR_URL } from './strings';
 
 export type HttpClientOptionType = 'baseURL' | 'headers' | 'withCredentials' | 'responseType' | 'xsrfCookieName' | 'xsrfHeaderName' | 'onUploadProgress' | 'onDownloadProgress' | 'httpAgent' | 'httpsAgent' | 'cancelToken';
-export type HttpClientOptions = Pick<AxiosRequestConfig, HttpClientOptionType>;
+export type SlimAxiosRequestConfig = Pick<AxiosRequestConfig, HttpClientOptionType>;
 
 /** Config used for setting up http calls */
 export interface ApiConfig {
   /** If specified, a new axios instance is used instead of the one instantiated in the HttpClient's constructor */
   noGlobal?: boolean;
-  /** The headers that will be used in the HTTP call. Global headers will be added to these. */
+  /** The headers that will be used in the HTTP call. Global headers will be added to these.
+   *
+   * TODO - Test when noGlobal is true if global headers are added to the request
+  */
   headers?: Record<string, string>;
   /** The body of the request that will be sent */
   data?: any;
@@ -72,6 +75,11 @@ export class MaxRetryHttpRequestStrategy implements HttpRequestStrategy {
   }
 }
 
+export interface HttpClientOptions {
+  axiosOptions?: SlimAxiosRequestConfig,
+  httpRequestStrategy?: HttpRequestStrategy,
+}
+
 /** Typed wrapper around axios that standardizes making HTTP calls and handling responses */
 export class HttpClient {
   /** Base axios instance this class will use */
@@ -83,7 +91,8 @@ export class HttpClient {
    * Typed wrapper around axios that standardizes making HTTP calls and handling responses
    * @param axiosOptions Options that will be passed to axios
    */
-  constructor (axiosOptions?: HttpClientOptions, httpRequestStrategy?: HttpRequestStrategy) {
+  constructor (options: HttpClientOptions = {}) {
+    const { axiosOptions, httpRequestStrategy } = options;
     this.client = axios.create(axiosOptions);
     this.httpRequestStrategy = httpRequestStrategy ?? new DefaultHttpRequestStrategy();
   }

--- a/src/HttpRequestStrategies/DefaultHttpRequestStrategy.test.ts
+++ b/src/HttpRequestStrategies/DefaultHttpRequestStrategy.test.ts
@@ -1,0 +1,69 @@
+import { DefaultHttpRequestStrategy, HttpResponse } from '../index';
+import MockAdapter from 'axios-mock-adapter';
+import axios, { AxiosInstance, AxiosRequestConfig } from 'axios';
+
+const mock = new MockAdapter(axios, { delayResponse: 1000 });
+
+const successfulResponseData: Partial<HttpResponse<string>> = {
+  data:       'data',
+  status:     200,
+  headers:    {},
+  statusText: undefined,
+};
+
+const failedResponseData: Partial<HttpResponse<string>> = {
+  status:     400,
+  headers:    {},
+  statusText: undefined,
+};
+
+describe('DefaultHttpRequestStrategy', () => {
+
+  let create: (config?: AxiosRequestConfig<any> | undefined) => AxiosInstance;
+
+  beforeEach(() => {
+    jest.resetModules();
+    jest.resetAllMocks();
+    mock.reset();
+    create = axios.create;
+  });
+
+  afterEach(() => {
+    axios.create = create;
+  });
+
+  it('should be defined', () => {
+    expect(new DefaultHttpRequestStrategy()).toBeDefined();
+  });
+
+  it('request - successful', async () => {
+    expect.assertions(2);
+    const strategy = new DefaultHttpRequestStrategy();
+
+    const request = jest.fn((_config: any) => Promise.resolve(successfulResponseData));
+    const create = jest.fn().mockImplementation(() => ({ request }));
+    axios.create = create;
+    const client = axios.create();
+    const axiosConfig: AxiosRequestConfig = {};
+
+    const response = await strategy.request(client, axiosConfig);
+
+    expect(successfulResponseData.data).toEqual(response.data);
+    expect(client.request).toBeCalledTimes(1);
+  });
+
+  it('request - error - throws', async () => {
+    expect.assertions(2);
+    const strategy = new DefaultHttpRequestStrategy();
+
+    const request = jest.fn((_config: any) => Promise.resolve(failedResponseData));
+    const create = jest.fn().mockImplementation(() => ({ request }));
+    axios.create = create;
+    const client = axios.create();
+    const axiosConfig: AxiosRequestConfig = {};
+
+
+    await expect(() => strategy.request(client, axiosConfig)).rejects.toEqual(failedResponseData);
+    expect(client.request).toBeCalledTimes(1);
+  });
+});

--- a/src/HttpRequestStrategies/DefaultHttpRequestStrategy.ts
+++ b/src/HttpRequestStrategies/DefaultHttpRequestStrategy.ts
@@ -3,7 +3,7 @@ import { HttpResponse, getIsSuccessfulHttpStatus, HttpRequestStrategy } from '..
 
 /** The default HTTP request strat. No logic. */
 export class DefaultHttpRequestStrategy implements HttpRequestStrategy {
-  /** Passthrough request to axios */
+  /** Passthrough request to axios and check response is successful */
   public async request<T = unknown> (client: AxiosInstance, axiosConfig: AxiosRequestConfig) {
     const response = await client.request<T>(axiosConfig);
     this.checkResponseStatus<T>(response);

--- a/src/HttpRequestStrategies/DefaultHttpRequestStrategy.ts
+++ b/src/HttpRequestStrategies/DefaultHttpRequestStrategy.ts
@@ -1,0 +1,21 @@
+import { AxiosInstance, AxiosRequestConfig } from 'axios';
+import { HttpResponse, getIsSuccessfulHttpStatus, HttpRequestStrategy } from '../index';
+
+/** The default HTTP request strat. No logic. */
+export class DefaultHttpRequestStrategy implements HttpRequestStrategy {
+  /** Passthrough request to axios */
+  public async request<T = unknown> (client: AxiosInstance, axiosConfig: AxiosRequestConfig) {
+    const response = await client.request<T>(axiosConfig);
+    this.checkResponseStatus<T>(response);
+    return response;
+  }
+
+  /** Validates the HTTP response is successful or throws an error */
+  private checkResponseStatus<T = unknown> (response: HttpResponse<T>): HttpResponse<T> {
+    const isSuccessful = getIsSuccessfulHttpStatus(response.status);
+    if (isSuccessful) {
+      return response;
+    }
+    throw response;
+  }
+}

--- a/src/HttpRequestStrategies/HttpRequestStrategy.ts
+++ b/src/HttpRequestStrategies/HttpRequestStrategy.ts
@@ -1,0 +1,7 @@
+import { AxiosInstance, AxiosRequestConfig, AxiosResponse } from 'axios';
+
+/** How HTTP calls will be handled. */
+export interface HttpRequestStrategy {
+  /** Wrapper request around axios to add request and resposne logic */
+  request: <T = unknown>(client: AxiosInstance, axiosConfig: AxiosRequestConfig) => Promise<AxiosResponse<T, any>>
+}

--- a/src/HttpRequestStrategies/MaxRetryHttpRequestStrategy.test.ts
+++ b/src/HttpRequestStrategies/MaxRetryHttpRequestStrategy.test.ts
@@ -1,0 +1,166 @@
+import { MaxRetryHttpRequestStrategy, HttpResponse } from '../index';
+import MockAdapter from 'axios-mock-adapter';
+import axios, { AxiosInstance, AxiosRequestConfig } from 'axios';
+
+const mock = new MockAdapter(axios, { delayResponse: 1000 });
+
+const successfulResponseData: Partial<HttpResponse<string>> = {
+  data:       'data',
+  status:     200,
+  headers:    {},
+  statusText: undefined,
+};
+
+const failedResponseData: Partial<HttpResponse<string>> = {
+  status:     400,
+  headers:    {},
+  statusText: undefined,
+};
+
+const tooManyRequestsResponseData: Partial<HttpResponse<string>> = {
+  status:     429,
+  headers:    {},
+  statusText: undefined,
+};
+
+describe('MaxRetryHttpRequestStrategy', () => {
+
+  let create: (config?: AxiosRequestConfig<any> | undefined) => AxiosInstance;
+
+  beforeEach(() => {
+    jest.resetModules();
+    jest.resetAllMocks();
+    mock.reset();
+    create = axios.create;
+  });
+
+  afterEach(() => {
+    axios.create = create;
+  });
+
+  it('should be defined', () => {
+    expect(new MaxRetryHttpRequestStrategy()).toBeDefined();
+  });
+
+  it('should default maxRetryCount', () => {
+    const strategy = new MaxRetryHttpRequestStrategy();
+    expect((strategy as any).maxRetryCount).toEqual(5);
+  });
+
+  it('should accept a maxRetryCount', () => {
+    const maxRetryCount = 10;
+    const strategy = new MaxRetryHttpRequestStrategy(maxRetryCount);
+    expect((strategy as any).maxRetryCount).toEqual(maxRetryCount);
+  });
+
+  it('should request once on a success response', async () => {
+    expect.assertions(2);
+    const strategy = new MaxRetryHttpRequestStrategy();
+    const request = jest.fn((_config: any) => Promise.resolve(successfulResponseData));
+    const create = jest.fn().mockImplementation(() => ({ request }));
+    axios.create = create;
+    const client = axios.create();
+    const axiosConfig: AxiosRequestConfig = {};
+
+    const response = await strategy.request(client, axiosConfig);
+
+    expect(successfulResponseData.data).toEqual(response.data);
+    expect(client.request).toBeCalledTimes(1);
+  });
+
+  it('should request until successful, 1 failed, 1 success, 5 max', async () => {
+    expect.assertions(2);
+    const strategy = new MaxRetryHttpRequestStrategy(5);
+
+    let requestCount = 0;
+
+    const request = jest.fn((_config: any) => {
+      if (requestCount === 0) {
+        requestCount += 1;
+        return Promise.resolve(failedResponseData);
+      }
+      requestCount += 1;
+      return Promise.resolve(successfulResponseData);
+    });
+    const create = jest.fn().mockImplementation(() => ({ request }));
+    axios.create = create;
+    const client = axios.create();
+    const axiosConfig: AxiosRequestConfig = {};
+
+    const response = await strategy.request(client, axiosConfig);
+
+    expect(response.data).toEqual(successfulResponseData.data);
+    expect(client.request).toBeCalledTimes(2);
+  });
+
+  it('should request until maxRetryCount, 10 failed, 0 success, 10 max', async () => {
+    expect.assertions(2);
+    const maxRetryCount = 10;
+    const strategy = new MaxRetryHttpRequestStrategy(maxRetryCount);
+
+    const request = jest.fn((_config: any) => {
+      return Promise.resolve(failedResponseData);
+    });
+    const create = jest.fn().mockImplementation(() => ({ request }));
+    axios.create = create;
+    const client = axios.create();
+    const axiosConfig: AxiosRequestConfig = {};
+
+    const response = await strategy.request(client, axiosConfig);
+
+    expect(response.data).toEqual(failedResponseData.data);
+    expect(client.request).toBeCalledTimes(maxRetryCount);
+  });
+
+  it('should request until hits TOO_MANY_REQUESTS_STATUS, 3 failed, 1 TOO_MANY..., 5 max', async () => {
+    expect.assertions(2);
+    const strategy = new MaxRetryHttpRequestStrategy(5);
+
+    let requestCount = 0;
+
+    const request = jest.fn((_config: any) => {
+      if (requestCount === 3) {
+        requestCount += 1;
+        return Promise.resolve(tooManyRequestsResponseData);
+      }
+      requestCount += 1;
+      return Promise.resolve(failedResponseData);
+    });
+    const create = jest.fn().mockImplementation(() => ({ request }));
+    axios.create = create;
+    const client = axios.create();
+    const axiosConfig: AxiosRequestConfig = {};
+
+    const response = await strategy.request(client, axiosConfig);
+
+    expect(response.data).toEqual(tooManyRequestsResponseData.data);
+    expect(client.request).toBeCalledTimes(4);
+  });
+
+  it('should request forever if a zero is passed for maxRetryCount, 99 failed, 1 success..., 0 max', async () => {
+    expect.assertions(2);
+    const maxRetryCount = 0;
+    const strategy = new MaxRetryHttpRequestStrategy(maxRetryCount);
+
+    let requestCount = 0;
+
+    const request = jest.fn((_config: any) => {
+      if (requestCount === 99) {
+        requestCount += 1;
+        return Promise.resolve(successfulResponseData);
+      }
+      requestCount += 1;
+      return Promise.resolve(failedResponseData);
+    });
+    const create = jest.fn().mockImplementation(() => ({ request }));
+    axios.create = create;
+    const client = axios.create();
+    const axiosConfig: AxiosRequestConfig = {};
+
+    const response = await strategy.request(client, axiosConfig);
+    console.log(requestCount);
+
+    expect(response.data).toEqual(successfulResponseData.data);
+    expect(client.request).toBeCalledTimes(100);
+  });
+});

--- a/src/HttpRequestStrategies/MaxRetryHttpRequestStrategy.ts
+++ b/src/HttpRequestStrategies/MaxRetryHttpRequestStrategy.ts
@@ -1,0 +1,34 @@
+import { AxiosInstance, AxiosRequestConfig, AxiosResponse } from 'axios';
+import { getIsSuccessfulHttpStatus, HttpRequestStrategy } from '../index';
+
+/** Retrys HTTP requests immediatly on non successful HTTP request until the max retry count.
+ *  Stops retrying when a TOO MANY REQUESTS STATUS is recieved (status code: 429)
+ */
+export class MaxRetryHttpRequestStrategy implements HttpRequestStrategy {
+
+  /** TOO MANY REQUESTS STATUS CODE */
+  private TOO_MANY_REQUESTS_STATUS = 429;
+
+  /**
+   * @param maxRetryCount - The maximum number of retries to attempt, default is 5, set to 0 for indefinite retries
+   */
+  constructor (private maxRetryCount: number = 5) { }
+
+  public async request<T = unknown> (client: AxiosInstance, axiosConfig: AxiosRequestConfig): Promise<AxiosResponse<T, any>> {
+    let response: AxiosResponse<T, any>;
+    let retryCount = 0;
+    let isSuccessfulHttpStatus = false;
+    let isTooManyRequests = false;
+    let isAtRetryLimit = false;
+
+    const increment = this.maxRetryCount <= 0 ? 0 : 1;
+    do {
+      retryCount += increment;
+      response = await client.request<T>(axiosConfig);
+      isSuccessfulHttpStatus = getIsSuccessfulHttpStatus(response.status);
+      isTooManyRequests = response.status === this.TOO_MANY_REQUESTS_STATUS;
+      isAtRetryLimit = this.maxRetryCount === 0 ? false : retryCount >= this.maxRetryCount;
+    } while (!isSuccessfulHttpStatus && !isTooManyRequests && !isAtRetryLimit);
+    return response;
+  }
+}

--- a/src/HttpRequestStrategies/index.ts
+++ b/src/HttpRequestStrategies/index.ts
@@ -1,0 +1,3 @@
+export * from './HttpRequestStrategy';
+export * from './DefaultHttpRequestStrategy';
+export * from './MaxRetryHttpRequestStrategy';

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,3 +3,5 @@ export * from './Logger';
 export * from './errors/HttpError';
 export * from './errors/AbortError';
 export * from './errors/isHttpError';
+export * from './HttpRequestStrategies';
+export * from './utilities/getIsSuccessfulHttpStatus';

--- a/src/utilities/getIsSuccessfulHttpStatus.test.ts
+++ b/src/utilities/getIsSuccessfulHttpStatus.test.ts
@@ -1,0 +1,21 @@
+import { getIsSuccessfulHttpStatus } from './getIsSuccessfulHttpStatus';
+
+describe('getIsSuccessfulHttpStatus', () => {
+  it('should return true if status is between 200 and 299', () => {
+    expect.assertions(100);
+    for (let i = 200; i <= 299; i++) {
+      const result = getIsSuccessfulHttpStatus(i);
+      expect(result).toBe(true);
+    }
+  });
+  it('should return false if status is greater than 300', () => {
+    expect.assertions(1);
+    const result = getIsSuccessfulHttpStatus(300);
+    expect(result).toBe(false);
+  });
+  it('should return false if status is less than 200', () => {
+    expect.assertions(1);
+    const result = getIsSuccessfulHttpStatus(199);
+    expect(result).toBe(false);
+  });
+});

--- a/src/utilities/getIsSuccessfulHttpStatus.ts
+++ b/src/utilities/getIsSuccessfulHttpStatus.ts
@@ -1,0 +1,4 @@
+/** Function to determine if a HTTP status code is in the successful range (2XX) */
+export function getIsSuccessfulHttpStatus (status: number): boolean {
+  return status >= 200 && status < 300;
+}


### PR DESCRIPTION
This PR is to add and expose the interface `HttpRequestStrategy` to allow consumers to change the behavior of how requests and responses are handled.

This allows things like auto retrying all HTTP calls, exponential backoffs, additional logging, response data transformations, header stripping, etc.

Addresses issue: #3 